### PR TITLE
TD-6192: EndDate and LastAccessDate columns showing null scenario has been handled

### DIFF
--- a/local/mylearningservice/externallib.php
+++ b/local/mylearningservice/externallib.php
@@ -62,9 +62,15 @@ class mylearningservice_external extends external_api {
     }
         
          $enrolrecords = $DB->get_records_sql("
-             SELECT ue.timestart,ue.timeend
+             SELECT ue.timestart, cc.timecompleted ,ula.timeaccess
              FROM {user_enrolments} ue
              JOIN {enrol} e ON ue.enrolid = e.id
+             LEFT JOIN {course_completions} cc
+                ON cc.userid = ue.userid 
+                AND cc.course = e.courseid
+            LEFT JOIN {user_lastaccess} ula
+                ON ula.userid = ue.userid 
+                AND ula.courseid = e.courseid
              WHERE ue.userid = :userid AND e.courseid = :courseid
              ORDER BY ue.timestart DESC
          ", [
@@ -77,7 +83,8 @@ class mylearningservice_external extends external_api {
          if (!empty($enrolrecords)) {
              $firstrecord = reset($enrolrecords); // Gets first item
              $enroltime = (int)$firstrecord->timestart;
-             $enrolendtime=(int)$firstrecord->timeend;
+             $enrolendtime=(int)$firstrecord->timecompleted;
+             $lastaccessdate =(int)$firstrecord->timeaccess;
          }
          if(!empty($months))
          {
@@ -220,7 +227,8 @@ class mylearningservice_external extends external_api {
              'timemodified' => $course->timemodified,
              'certificateenabled'=>$hascertificate,
              'totalactivities' => $totalactivities,
-             'completedactivities'=>$completedactivities
+             'completedactivities'=>$completedactivities,
+             'lastaccessdate'=>$lastaccessdate
 
          ];
          if ($returnusercount) {
@@ -286,6 +294,7 @@ class mylearningservice_external extends external_api {
                     'certificateenabled' => new external_value(PARAM_BOOL, 'Whether the course has certificate.', VALUE_OPTIONAL),
                     'totalactivities' => new external_value(PARAM_INT, 'total activities', VALUE_OPTIONAL),
                     'completedactivities' => new external_value(PARAM_INT, 'completed activities count', VALUE_OPTIONAL),
+                    'lastaccessdate' => new external_value(PARAM_INT, 'Timestamp when the user access the course last', VALUE_OPTIONAL),
                 )
             )
         );

--- a/local/mylearningservice/version.php
+++ b/local/mylearningservice/version.php
@@ -2,7 +2,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_mylearningservice';
-$plugin->version = 2025073105;
+$plugin->version = 2025073106;
 $plugin->requires = 2024100290;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = '1.0';


### PR DESCRIPTION
Please find below sql query which is used in moodle end point. This has been tested in moodle-dev and moodle-test DBs and the result is meeting the expectation. Unfortunately requires more effort to make it configure in local and required complete a course as well.

To 
<img width="252" height="248" alt="image" src="https://github.com/user-attachments/assets/433f3ebe-4ccb-421f-9462-afd290bd3032" />
