### PR TITLE
TD-6195: SCORM package name should be in the file name when package is uploaded usig migration tool

### DIFF
--- a/local/scormresource/externallib.php
+++ b/local/scormresource/externallib.php
@@ -99,7 +99,7 @@ class insert_scorm_resource extends external_api {
             'filearea'  => 'package',
             'itemid'    => 0, // Item ID (could be used to reference a specific instance of the package)
             'filepath'  => '/',
-            'filename'  => $file. '.zip'
+            'filename'  => $foldername. '.zip'
         );
         $file = $fs->create_file_from_pathname($fileinfo, $scormfile);
         

--- a/local/scormresource/version.php
+++ b/local/scormresource/version.php
@@ -1,7 +1,7 @@
 <?php
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024100990;        
+$plugin->version   = 2024100991;        
 $plugin->requires  = 2024100290;        
 $plugin->component = 'local_scormresource'; 
 $plugin->privacy = ['provider' => 'local_scormresource\privacy\provider'];


### PR DESCRIPTION

**_Before fix:_**
<img width="643" height="374" alt="image" src="https://github.com/user-attachments/assets/7b1cf8a2-bc79-4967-b600-b838daf06ec6" />


**_After fix:_**

<img width="836" height="490" alt="image" src="https://github.com/user-attachments/assets/2fde8f58-58eb-4c97-926e-3d22bb3aca29" />
